### PR TITLE
Upgrade integration tests to Fabric v1.3 (resolves #2)

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -33,8 +33,14 @@ else
     mkdir tmp
 fi
 
+for IMAGE in hyperledger/fabric-ca hyperledger/fabric-orderer hyperledger/fabric-peer hyperledger/fabric-tools hyperledger/fabric-ccenv
+do
+    docker pull nexus3.hyperledger.org:10001/${IMAGE}:amd64-1.3.0-stable
+    docker tag nexus3.hyperledger.org:10001/${IMAGE}:amd64-1.3.0-stable ${IMAGE}
+done
+
 pushd tmp
-git clone -b release-1.2 https://github.com/hyperledger/fabric-samples.git
+git clone -b master https://github.com/hyperledger/fabric-samples.git
 pushd fabric-samples/basic-network
 export FABRIC_DIR="$(pwd)"
 ./start.sh


### PR DESCRIPTION
Upgrade the integration tests so that they pull the latest Fabric v1.3 stable Docker images from Hyperledger's Nexus repository, and tag them as `latest` so they get used by the `basic-network` sample. Also switch to using the `master` branch of the `fabric-samples` repository to get the Fabric v1.3 samples.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>