### PR TITLE
Rename startChaincode to fabric-chaincode-node (resolves #13)

### DIFF
--- a/generators/contract/templates/javascript/package.json
+++ b/generators/contract/templates/javascript/package.json
@@ -11,7 +11,7 @@
         "lint": "eslint .",
         "pretest": "npm run lint",
         "test": "nyc mocha --recursive",
-        "start": "startChaincode"
+        "start": "fabric-chaincode-node start"
     },
     "engineStrict": true,
     "author": "<%= author %>",

--- a/generators/contract/templates/typescript/package.json
+++ b/generators/contract/templates/typescript/package.json
@@ -12,7 +12,7 @@
         "lint": "tslint -c tslint.json 'src/**/*.ts'",
         "pretest": "npm run lint",
         "test": "nyc mocha -r ts-node/register src/**/*.spec.ts",
-        "start": "startChaincode",
+        "start": "fabric-chaincode-node start",
         "build": "tsc",
         "build:watch": "tsc -w",
         "prepublishOnly": "npm run build"

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -225,7 +225,7 @@ javascript_contract_deploy() {
         --network net_basic \
         --rm \
         hyperledger/fabric-tools \
-        peer chaincode instantiate -o orderer.example.com:7050 -C mychannel -n ${LANGUAGE}-contract -v 0.0.1 -l node -c '{"Args":["contract_instantiate"]}'
+        peer chaincode instantiate -o orderer.example.com:7050 -C mychannel -n ${LANGUAGE}-contract -v 0.0.1 -l node -c '{"Args":["instantiate"]}'
     date
 }
 
@@ -256,7 +256,7 @@ typescript_contract_deploy() {
         --network net_basic \
         --rm \
         hyperledger/fabric-tools \
-        peer chaincode instantiate -o orderer.example.com:7050 -C mychannel -n ${LANGUAGE}-contract -v 0.0.1 -l node -c '{"Args":["contract_instantiate"]}'
+        peer chaincode instantiate -o orderer.example.com:7050 -C mychannel -n ${LANGUAGE}-contract -v 0.0.1 -l node -c '{"Args":["instantiate"]}'
     date
 }
 
@@ -271,7 +271,7 @@ common_contract_test() {
         --network net_basic \
         --rm \
         hyperledger/fabric-tools \
-        peer chaincode invoke -o orderer.example.com:7050 -C mychannel -n ${LANGUAGE}-contract -c '{"Args":["contract_transaction1","hello"]}' --waitForEvent
+        peer chaincode invoke -o orderer.example.com:7050 -C mychannel -n ${LANGUAGE}-contract -c '{"Args":["transaction1","hello"]}' --waitForEvent
     date
     ${RETRY} docker run \
         -e "CORE_PEER_ADDRESS=peer0.org1.example.com:7051" \
@@ -282,7 +282,7 @@ common_contract_test() {
         --network net_basic \
         --rm \
         hyperledger/fabric-tools \
-        peer chaincode invoke -o orderer.example.com:7050 -C mychannel -n ${LANGUAGE}-contract -c '{"Args":["contract_transaction2","hello","world"]}' --waitForEvent
+        peer chaincode invoke -o orderer.example.com:7050 -C mychannel -n ${LANGUAGE}-contract -c '{"Args":["transaction2","hello","world"]}' --waitForEvent
     date
 }
 

--- a/test/contract/javascript.js
+++ b/test/contract/javascript.js
@@ -68,7 +68,7 @@ describe('Contract (JavaScript)', () => {
                 lint: 'eslint .',
                 pretest: 'npm run lint',
                 test: 'nyc mocha --recursive',
-                start: 'startChaincode'
+                start: 'fabric-chaincode-node start'
             },
             engineStrict: true,
             author: 'James Conga',

--- a/test/contract/typescript.js
+++ b/test/contract/typescript.js
@@ -69,7 +69,7 @@ describe('Contract (TypeScript)', () => {
                 lint: 'tslint -c tslint.json \'src/**/*.ts\'',
                 pretest: 'npm run lint',
                 test: 'nyc mocha -r ts-node/register src/**/*.spec.ts',
-                start: 'startChaincode',
+                start: 'fabric-chaincode-node start',
                 build: 'tsc',
                 'build:watch': 'tsc -w',
                 prepublishOnly: 'npm run build'


### PR DESCRIPTION
Rename `startChaincode` to `fabric-chaincode-node` in the `package.json` files for the JavaScript and TypeScript smart contract generators.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>