### PR TITLE
Automatically run npm install after generation (resolves #15)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -13,3 +13,4 @@
 #
 
 coverage
+tmp

--- a/generators/chaincode/index.js
+++ b/generators/chaincode/index.js
@@ -70,4 +70,10 @@ module.exports = class extends Generator {
         this.fs.copyTpl(this.templatePath(this.options.language), this.destinationRoot(), this.options, undefined, { globOptions: { dot: true } });
     }
 
+    async install() {
+        if (this.options.language === 'javascript' || this.options.language === 'typescript') {
+            this.installDependencies({ bower: false, npm: true });
+        }
+    }
+
 };

--- a/generators/contract/index.js
+++ b/generators/contract/index.js
@@ -69,4 +69,8 @@ module.exports = class extends Generator {
         this.fs.copyTpl(this.templatePath(this.options.language), this.destinationRoot(), this.options, undefined, { globOptions: { dot: true } });
     }
 
+    async install() {
+        this.installDependencies({ bower: false, npm: true });
+    }
+
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
         "exclude": [
             "coverage/**",
             "generators/**/templates/**",
-            "test/**"
+            "test/**",
+            "tmp/**"
         ],
         "reporter": [
             "text-summary",

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -108,7 +108,6 @@ go_chaincode_deploy() {
 
 javascript_chaincode_deploy() {
     yo fabric:chaincode -- --language=${LANGUAGE} --author="Lord Conga" --description="Lord Conga's Chaincode" --name=${LANGUAGE}-chaincode --version=0.0.1 --license=Apache-2.0
-    npm install
     npm test
     date
     ${RETRY} docker run \
@@ -138,7 +137,6 @@ javascript_chaincode_deploy() {
 
 typescript_chaincode_deploy() {
     yo fabric:chaincode -- --language=${LANGUAGE} --author="Lord Conga" --description="Lord Conga's Chaincode" --name=${LANGUAGE}-chaincode --version=0.0.1 --license=Apache-2.0
-    npm install
     npm test
     npm run build
     date
@@ -201,7 +199,6 @@ contract_test() {
 
 javascript_contract_deploy() {
     yo fabric:contract -- --language=${LANGUAGE} --author="Lord Conga" --description="Lord Conga's Smart Contract" --name=${LANGUAGE}-contract --version=0.0.1 --license=Apache-2.0
-    npm install
     npm test
     date
     ${RETRY} docker run \
@@ -231,7 +228,6 @@ javascript_contract_deploy() {
 
 typescript_contract_deploy() {
     yo fabric:contract -- --language=${LANGUAGE} --author="Lord Conga" --description="Lord Conga's Smart Contract" --name=${LANGUAGE}-contract --version=0.0.1 --license=Apache-2.0
-    npm install
     npm test
     npm run build
     date


### PR DESCRIPTION
Automatically run npm install after generation when generating a JavaScript or TypeScript chaincode or smart contract. This matches up with the suggested behaviour of Yeoman generators in the Yeoman documentation.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>